### PR TITLE
Modify IPv6 Address Filtering Strategy

### DIFF
--- a/src/chinadns.c
+++ b/src/chinadns.c
@@ -806,8 +806,11 @@ static int should_filter_query(ns_msg msg, struct in_addr dns_addr) {
           return 1;
         }
       }
-    } else if (type == ns_t_aaaa || type == ns_t_ptr) {
-      // if we've got an IPv6 result or a PTR result, pass
+    } else if (type == ns_t_aaaa) {
+      if (dns_is_chn) {
+        return 1;
+      }
+    } else if (type == ns_t_ptr) {
       return 0;
     }
   }


### PR DESCRIPTION
If ChinaDNS received an AAAA record, drop if it's from China DNS server and pass if not so that users won't get a poisoned AAAA record.
This strategy may be very useful for users of IPv6 (like CERNET2) if their IPv6 network has higher priority than IPv4.